### PR TITLE
Added missing  node module "alphanum-sort"

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "alphanum-sort": "^1.0.2",
     "escape-string-regexp": "^1.0.5",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",


### PR DESCRIPTION
It was missing. Now it’s here.